### PR TITLE
match element not whole pattern

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,9 +11,10 @@ exports.register = function(plugin, options, next){
     var urlPath = request.url.pathname.split('/');
     urlPath[0] === '' ? urlPath.shift() : null;
     var reqHeader = request.headers[versionHeader];
+    var version = reqHeader.match(pattern);
 
-    if (pattern.test(reqHeader) && !pattern.test(urlPath[0])){
-      urlPath.unshift('', reqHeader);
+    if (version && !pattern.test(urlPath[0])){
+      urlPath.unshift('', version[1]);
       request.setUrl(urlPath.join('/'));
     }
 


### PR DESCRIPTION
using such options :

``` js
Server.register({
  register: require('hapi-versioning'),
  options: {
    pattern: /application\/vnd\.foo\+json; version=(v\d+)/,
    header: 'accept'
  }}, () => {})
```

match whole pattern : it tooks for `/application/vnd.foo+json; version=v1/bar` instead of  `/v1/bar`

this patch fixes this behavior
